### PR TITLE
Detect CI changes and don't fail the job

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -269,7 +269,8 @@ index 0000000..17e1150
 
     #[test]
     fn test_changed_packages_with_subdir() {
-        let packages = changed_packages(SAMPLE_DIFF_WITH_SUBDIR).unwrap();
+        let patches = Patch::from_multiple(SAMPLE_DIFF_WITH_SUBDIR).unwrap();
+        let packages = changed_packages(patches).unwrap();
         assert_eq!(packages.len(), 1);
         assert_eq!(
             packages[0].id,

--- a/src/package.rs
+++ b/src/package.rs
@@ -37,8 +37,7 @@ impl<'a> From<gitpatch::ParseError<'a>> for Error {
     }
 }
 
-pub fn changed_packages(diff: &str) -> Result<Vec<Package>, Error> {
-    let patches = Patch::from_multiple(diff)?;
+pub fn changed_packages(patches: Vec<Patch>) -> Result<Vec<Package>, Error> {
     let mut ret = Vec::new();
     for patch in patches {
         let path = patch.new.path;
@@ -262,7 +261,8 @@ index 0000000..17e1150
 
     #[test]
     fn test_changed_packages() {
-        let packages = changed_packages(SAMPLE_DIFF).unwrap();
+        let patches = Patch::from_multiple(SAMPLE_DIFF).unwrap();
+        let packages = changed_packages(patches).unwrap();
         assert_eq!(packages.len(), 1);
         assert_eq!(packages[0].version, SemVer::new(0, 2, 0));
     }


### PR DESCRIPTION
It's annoying to change the nickel-mine ci because nickel-customs always complains.

This PR weakens nickel-customs checks so that it warns but doesn't fail if a PR modifies the nickel-mine CI.